### PR TITLE
Ansible Role: remove-account: add user clean up tasks

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -11,6 +11,8 @@ vault_password_file = vault.password.py
 
 log_path = ansible.log
 
+roles_path = ./roles
+
 # Log how long each Ansible task takes to run.
 # Reference: http://stackoverflow.com/a/29132716/1851299
 callback_whitelist = profile_tasks, profile_roles

--- a/roles/remove_account/tasks/main.yml
+++ b/roles/remove_account/tasks/main.yml
@@ -29,3 +29,4 @@
   loop_control:
     loop_var: username
     extended: true
+  when: remove_account_usernames is defined and remove_account_usernames | length > 0

--- a/roles/remove_account/tasks/main.yml
+++ b/roles/remove_account/tasks/main.yml
@@ -11,6 +11,10 @@
       ansible.builtin.include_vars: Raspios.yml
       when: rpi.stat.exists
 
+    - name: Include variables for Debian
+      ansible.builtin.include_vars: Debian.yml
+      when: ansible_distribution == 'Debian' and not rpi.stat.exists
+
     - name: Include variables for Ubuntu
       ansible.builtin.include_vars: Ubuntu.yml
       when: ansible_distribution == 'Ubuntu'

--- a/roles/remove_account/tasks/remove_account.yml
+++ b/roles/remove_account/tasks/remove_account.yml
@@ -3,6 +3,21 @@
   ansible.builtin.debug:
     msg: "Processing {{ ansible_loop.index }}/{{ ansible_loop.length }}: {{ username }}"
 
+# If the user exists, then run pkill.
+#
+# pkill return codes:
+#   0 → processes killed successfully
+#   1 → the user exists but has no running processes (valid case)
+#   2 → invalid user (prevented by the getent check)
+#
+# '|| true' prevents task failure if no processes are running (rc 1).
+- name: Kill any processes owned by the user
+  ansible.builtin.shell: |
+    if getent passwd {{ username }} >/dev/null; then
+      pkill -u {{ username }} || true
+    fi
+  changed_when: false
+
 - name: Remove user account
   ansible.builtin.user:
     name: "{{ username }}"

--- a/roles/remove_account/tasks/remove_account.yml
+++ b/roles/remove_account/tasks/remove_account.yml
@@ -23,6 +23,12 @@
     path: "/etc/sudoers.d/{{ username }}"
     state: absent
 
+- name: Remove user crontab if present
+  ansible.builtin.cron:
+    name: "all cron jobs"
+    user: "{{ username }}"
+    state: absent
+
 - name: Remove user account
   ansible.builtin.user:
     name: "{{ username }}"

--- a/roles/remove_account/tasks/remove_account.yml
+++ b/roles/remove_account/tasks/remove_account.yml
@@ -18,6 +18,11 @@
     fi
   changed_when: false
 
+- name: Remove user from sudoers if present
+  ansible.builtin.file:
+    path: "/etc/sudoers.d/{{ username }}"
+    state: absent
+
 - name: Remove user account
   ansible.builtin.user:
     name: "{{ username }}"

--- a/roles/remove_account/vars/Debian.yml
+++ b/roles/remove_account/vars/Debian.yml
@@ -1,0 +1,2 @@
+---
+remove_account_default_account: ""


### PR DESCRIPTION
This PR adds the following improvements to `ansible-role-remove-account`:

- [x] If the user exists then kill all processes owned by the user (prior to removing the user)
- [x] Remove user from sudoers if present
- [x] Remove user crontab if present
- [x] Add support for `ansible_distribution` == Debian
- [x] Only remove accounts when target usernames are defined
- [x] Set Ansible default roles path
