### PR TITLE
Ansible Role: ansible-bootstrap

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -18,7 +18,7 @@
       ignore_errors: true
 
     - name: End play if host is unreachable
-      meta: end_play
+      ansible.builtin.meta: end_play
       when: ping_result is defined and ping_result.unreachable is defined and ping_result.unreachable
 
     - name: Import ansible-prep role

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -21,9 +21,9 @@
       ansible.builtin.meta: end_play
       when: ping_result is defined and ping_result.unreachable is defined and ping_result.unreachable
 
-    - name: Import ansible-prep role
+    - name: Import ansible-bootstrap role
       ansible.builtin.import_role:
-        name: ansible_prep
+        name: ansible_bootstrap
 
     - name: Import security role
       ansible.builtin.import_role:

--- a/group_vars/bob_group/main.yml
+++ b/group_vars/bob_group/main.yml
@@ -1,2 +1,2 @@
 ---
-ansible_prep_upgrade_type: "full"
+ansible_bootstrap_upgrade_type: "full"

--- a/group_vars/yoshimo_group/main.yml
+++ b/group_vars/yoshimo_group/main.yml
@@ -1,6 +1,6 @@
 ---
-# MARK: Ansible Prep configuration.
-ansible_prep_upgrade_type: "full"
+# MARK: Ansible Bootstrap configuration.
+ansible_bootstrap_upgrade_type: "full"
 
 # MARK: RPi Hardware configuration.
 rpi_hardware_upgrade_firmware: true

--- a/roles/ansible_bootstrap/defaults/main.yml
+++ b/roles/ansible_bootstrap/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+ansible_bootstrap_upgrade_type: "safe"

--- a/roles/ansible_bootstrap/tasks/bootstrap_Debian.yml
+++ b/roles/ansible_bootstrap/tasks/bootstrap_Debian.yml
@@ -10,7 +10,7 @@
 
     - name: Upgrade all packages
       ansible.builtin.apt:
-        upgrade: "{{ ansible_prep_upgrade_type }}"
+        upgrade: "{{ ansible_bootstrap_upgrade_type }}"
         force_apt_get: true
       tags: ['upgrade']
   rescue:

--- a/roles/ansible_bootstrap/tasks/main.yml
+++ b/roles/ansible_bootstrap/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: Import Debian tasks
-  ansible.builtin.import_tasks: prep_Debian.yml
+  ansible.builtin.import_tasks: bootstrap_Debian.yml
   when: ansible_os_family == 'Debian'

--- a/roles/ansible_prep/defaults/main.yml
+++ b/roles/ansible_prep/defaults/main.yml
@@ -1,2 +1,0 @@
----
-ansible_prep_upgrade_type: "safe"

--- a/roles/ansible_prep/tasks/prep_Debian.yml
+++ b/roles/ansible_prep/tasks/prep_Debian.yml
@@ -14,7 +14,7 @@
         force_apt_get: true
       tags: ['upgrade']
   rescue:
-    - name: Debugging error during initial system upgrade
+    - name: "Debug: error during initial system upgrade"
       ansible.builtin.debug:
         msg: "An error occurred during the initial system upgrade."
 
@@ -38,6 +38,6 @@
         state: present
       tags: ['acl']
   rescue:
-    - name: Debugging error while install Ansible dependencies
+    - name: "Debug: error while install Ansible dependencies"
       ansible.builtin.debug:
         msg: "An error occurred while installing Ansible dependencies."

--- a/roles/ansible_prep/tasks/prep_Debian.yml
+++ b/roles/ansible_prep/tasks/prep_Debian.yml
@@ -20,7 +20,7 @@
 
 - name: Install Ansible dependencies
   block:
-    - name: Ensure python3 is installed
+    - name: Ensure libc-bin is installed
       ansible.builtin.package:
         name: "{{ item }}"
         state: present

--- a/roles/ansible_prep/tasks/prep_Debian.yml
+++ b/roles/ansible_prep/tasks/prep_Debian.yml
@@ -28,18 +28,14 @@
 
     - name: Ensure libc-bin is installed
       ansible.builtin.package:
-        name: "{{ item }}"
+        name: libc-bin
         state: present
-      loop:
-        - libc-bin
       tags: ['libc']
 
     - name: Ensure ACL is installed
       ansible.builtin.package:
-        name: "{{ item }}"
+        name: acl
         state: present
-      loop:
-        - acl
       tags: ['acl']
   rescue:
     - name: Debugging error while install Ansible dependencies

--- a/roles/ansible_prep/tasks/prep_Debian.yml
+++ b/roles/ansible_prep/tasks/prep_Debian.yml
@@ -20,19 +20,19 @@
 
 - name: Install Ansible dependencies
   block:
-    - name: Ensure Python 3 is installed
+    - name: Ensure Python 3 is installed (required for Ansible)
       ansible.builtin.package:
         name: python3
         state: present
       tags: ['python3']
 
-    - name: Ensure libc-bin is installed
+    - name: Ensure libc-bin is installed (required for core system utilities)
       ansible.builtin.package:
         name: libc-bin
         state: present
       tags: ['libc']
 
-    - name: Ensure ACL is installed
+    - name: Ensure ACL is installed (needed for advanced filesystem management)
       ansible.builtin.package:
         name: acl
         state: present

--- a/roles/ansible_prep/tasks/prep_Debian.yml
+++ b/roles/ansible_prep/tasks/prep_Debian.yml
@@ -20,6 +20,12 @@
 
 - name: Install Ansible dependencies
   block:
+    - name: Ensure Python 3 is installed
+      ansible.builtin.package:
+        name: python3
+        state: present
+      tags: ['python3']
+
     - name: Ensure libc-bin is installed
       ansible.builtin.package:
         name: "{{ item }}"

--- a/roles/ansible_prep/tasks/prep_Debian.yml
+++ b/roles/ansible_prep/tasks/prep_Debian.yml
@@ -26,6 +26,12 @@
         state: present
       tags: ['python3']
 
+    - name: Ensure python3-apt is installed (required for advanced package management)
+      ansible.builtin.package:
+        name: python3-apt
+        state: present
+      tags: ['python3-apt']
+
     - name: Ensure libc-bin is installed (required for core system utilities)
       ansible.builtin.package:
         name: libc-bin

--- a/roles/remove_account/tasks/main.yml
+++ b/roles/remove_account/tasks/main.yml
@@ -5,15 +5,15 @@
     - name: Check if running Raspberry Pi OS or some derivative of it
       ansible.builtin.stat:
         path: /etc/rpi-issue
-      register: rpi
+      register: remove_account_rpi
 
     - name: Include variables for Raspberry Pi OS
       ansible.builtin.include_vars: Raspios.yml
-      when: rpi.stat.exists
+      when: remove_account_rpi.stat.exists
 
     - name: Include variables for Debian
       ansible.builtin.include_vars: Debian.yml
-      when: ansible_distribution == 'Debian' and not rpi.stat.exists
+      when: ansible_distribution == 'Debian' and not remove_account_rpi.stat.exists
 
     - name: Include variables for Ubuntu
       ansible.builtin.include_vars: Ubuntu.yml

--- a/roles/rpi_hardware/meta/main.yml
+++ b/roles/rpi_hardware/meta/main.yml
@@ -1,3 +1,3 @@
 ---
 dependencies:
-  - role: ansible_prep
+  - role: ansible_bootstrap


### PR DESCRIPTION
This PR does the following:

- [x] Renames the role from `ansible_prep` to `ansible_bootstrap`
- [x] Ensures Python 3 is installed
- [x] Ensures `python3-apt` is installed for advanced package management features (E.g. querying package info)
- [x] Takes care of some ansible-lint errors
- [x] Improves readability
