### PR TITLE
Add Markdown Formatting and Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
 
 # Homelab
 
-This repository automates the setup of Raspberry Pis with services for my home network.
+This repository automates my home network setup.
+
+The automation is hardware-agnostic, but I like to run it on small single-board computers like
+Raspberry Pis. Think: small computers, big network!
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ Install the dependencies:
 ./pw pdm sync --no-update
 ```
 
-**Tip:** check which `pdm` is used:
+**Tip:** Make sure you're using the project's PDM, not a system-wide one:
 
 ```bash
 ./pw which pdm
 ```
 
-> The output should look something like:
+> The output should point to a path like:  
 > `<path_to_this_project>/Homelab/.pyprojectx/venvs/main-ab061d9d4f9bea1cc2de64816d469baf-py3.13/bin/pdm`
 
 #### 3b. Fixing a Broken Virtual Environment After a Homebrew Update

--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ Raspberry Pis. Think: small computers, big network!
 - [Ansible Roles](#ansible-roles)
   - [Security](#security)
 
+## Project Goals
+
+This project aims to:
+
+- [ ] Maintain a test environment that mirrors my home network for fast, safe deployment
+- [ ] Deploy across multiple OS and CPU architecture
+- [ ] Support both on-metal and cloud deployments
+- [ ] Ensure cross-OS service interoperability
+- [ ] Track [Ansible](https://www.ansible.com/) and [Salt](https://github.com/saltstack/salt)
+  configurations in parallel project branches for comparison
+
 ## Technologies Used
 
 Homelab makes use of the following tools:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ eval "$(pyenv init -)"
 Once pyenv is activated, it reads the `.python-version` file and activates the Python version
 specified there.
 
-> \[!Important\]
+> [!Important]
+>
 > - This command must be run **every time you start a new terminal session** before working on
 >   this project.
 > - You can run this command from any folder in the project.
@@ -85,7 +86,7 @@ Install the dependencies:
 ./pw which pdm
 ```
 
-> The output should point to a path like:  
+> The output should point to a path like:\
 > `<path_to_this_project>/Homelab/.pyprojectx/venvs/main-ab061d9d4f9bea1cc2de64816d469baf-py3.13/bin/pdm`
 
 #### 3b. Fixing a Broken Virtual Environment After a Homebrew Update
@@ -176,7 +177,7 @@ Before you do anything else, verify that you can connect to both the managing no
 ./pw pdm run --venv in-project ansible unprovisioned_yoshimo -m ping
 ```
 
-> \[!TIP\]
+> [!TIP]
 > See [`inventory.yml`](./inventory.yml) for other managed nodes.
 
 Now you should be good to go!

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ specified there.
 > \[!Important\]
 > - This command must be run **every time you start a new terminal session** before working on
 >   this project.
-> - You can run this command from any folder in the project.  
+> - You can run this command from any folder in the project.
 
 ### 3. Install Dependencies with Pyprojectx & PDM
 
@@ -71,7 +71,7 @@ isolated environment:
 
 - **Pyprojectx:** Provides the [`./pw`](./pw) wrapper script, ensuring all project tools run
   consistently without needing global installations (including PDM).
-- **PDM:** manages the Python dependencies used by this project (including Ansible).  
+- **PDM:** manages the Python dependencies used by this project (including Ansible).
 
 Install the dependencies:
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -2,10 +2,10 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default"]
+groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:94e3eae02c64dc5ae80f40c7917cc5fa242e9458fac858be3cb719892e6c1b57"
+content_hash = "sha256:fb1aa9c82acb72d3bcee72d32679386670b45ab7cad29665c357dd2037a20e9b"
 
 [[metadata.targets]]
 requires_python = "==3.13.*"
@@ -119,6 +119,20 @@ files = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+requires_python = ">=3.8"
+summary = "Python port of markdown-it. Markdown parsing, done right!"
+groups = ["dev"]
+dependencies = [
+    "mdurl~=0.1",
+]
+files = [
+    {file = "markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"},
+    {file = "markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1"},
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.2"
 requires_python = ">=3.9"
@@ -146,6 +160,33 @@ files = [
     {file = "MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6"},
     {file = "MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f"},
     {file = "markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0"},
+]
+
+[[package]]
+name = "mdformat"
+version = "0.7.22"
+requires_python = ">=3.9"
+summary = "CommonMark compliant Markdown formatter"
+groups = ["dev"]
+dependencies = [
+    "importlib-metadata>=3.6.0; python_version < \"3.10\"",
+    "markdown-it-py<4.0.0,>=1.0.0",
+    "tomli>=1.1.0; python_version < \"3.11\"",
+]
+files = [
+    {file = "mdformat-0.7.22-py3-none-any.whl", hash = "sha256:61122637c9e1d9be1329054f3fa216559f0d1f722b7919b060a8c2a4ae1850e5"},
+    {file = "mdformat-0.7.22.tar.gz", hash = "sha256:eef84fa8f233d3162734683c2a8a6222227a229b9206872e6139658d99acb1ea"},
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+requires_python = ">=3.7"
+summary = "Markdown URL utilities"
+groups = ["dev"]
+files = [
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,7 @@ requires-python = "==3.13.*"
 readme = "README.md"
 license = {text = "MIT"}
 
+[dependency-groups]
+dev = [
+    "mdformat>=0.7.22",
+]


### PR DESCRIPTION
This PR does the following:

- [x] Makes the project introduction punchier.
- [x] Improves the instructions for verifying project-specific PDM executable path.
- [x] Adds Markdown formating via `mdformat`.
- [x] Reformats the `README` using `mdformat`: `./pw pdm run mdformat README`.
- [x] Adds `Project Goals`.
